### PR TITLE
fix: Avoid a core JS parse warning.

### DIFF
--- a/gtm_barebones.libraries.yml
+++ b/gtm_barebones.libraries.yml
@@ -1,4 +1,4 @@
 gtm:
   version: 1.x
   js:
-    /gtm-load.js: { external: true, preprocess: false, minified: true, attributes: { defer: true } }
+    /gtm-load.js: { type: external, preprocess: false, minified: true, attributes: { defer: true } }


### PR DESCRIPTION
Specify correctly that the library should be considered external, so _locale_parse_js_file doesn't try to load it from disk.